### PR TITLE
Only set DYLD_LIBRARY_PATH in OS X Mountain Lion and older

### DIFF
--- a/InstallerTesting/mantidinstaller.py
+++ b/InstallerTesting/mantidinstaller.py
@@ -225,7 +225,9 @@ class DMGInstaller(MantidInstaller):
     def __init__(self, do_install):
         MantidInstaller.__init__(self, do_install, 'mantid-*.dmg')
         self.mantidPlotPath = '/Applications/MantidPlot.app/Contents/MacOS/MantidPlot'
-        os.environ['DYLD_LIBRARY_PATH'] = '/Applications/MantidPlot.app/Contents/MacOS'
+        # only necessary on 10.8 build
+        if platform.release().split('.')[0] < 13:
+            os.environ['DYLD_LIBRARY_PATH'] = '/Applications/MantidPlot.app/Contents/MacOS'
         
     def do_install(self):
         """Mounts the dmg and copies the application into the right place.

--- a/InstallerTesting/runSystemTests.py
+++ b/InstallerTesting/runSystemTests.py
@@ -71,7 +71,8 @@ sys.path.insert(0, mantid_module_path)
 # not the dynamic library path variable name
 if platform.system() == 'Windows':
   path_var = "PATH"
-elif platform.system() == 'Darwin':
+# only necessary on 10.8 build
+elif platform.system() == 'Darwin' and platform.release().split('.')[0] < 13 :
   path_var = "DYLD_LIBRARY_PATH"
 else:
   path_var = None


### PR DESCRIPTION
fixes ticket [#11085](http://trac.mantidproject.org/mantid/ticket/11085)

Setting DYLD_LIBRARY_PATH breaks the osx+clang build, so we'll only set it on Mountain Lion and older platforms.  

testing: Considering that these changes only affect one platform, code review is sufficient. 