### PR TITLE
Use integers when comparing OSX releases.

### DIFF
--- a/InstallerTesting/mantidinstaller.py
+++ b/InstallerTesting/mantidinstaller.py
@@ -226,7 +226,7 @@ class DMGInstaller(MantidInstaller):
         MantidInstaller.__init__(self, do_install, 'mantid-*.dmg')
         self.mantidPlotPath = '/Applications/MantidPlot.app/Contents/MacOS/MantidPlot'
         # only necessary on 10.8 build
-        if platform.release().split('.')[0] < 13:
+        if int(platform.release().split('.')[0]) < 13:
             os.environ['DYLD_LIBRARY_PATH'] = '/Applications/MantidPlot.app/Contents/MacOS'
         
     def do_install(self):

--- a/InstallerTesting/runSystemTests.py
+++ b/InstallerTesting/runSystemTests.py
@@ -72,7 +72,7 @@ sys.path.insert(0, mantid_module_path)
 if platform.system() == 'Windows':
   path_var = "PATH"
 # only necessary on 10.8 build
-elif platform.system() == 'Darwin' and platform.release().split('.')[0] < 13 :
+elif platform.system() == 'Darwin' and int(platform.release().split('.')[0]) < 13 :
   path_var = "DYLD_LIBRARY_PATH"
 else:
   path_var = None


### PR DESCRIPTION
In #12 a version check for OS X was introduced but there was a small bug when comparing the release numbers. 