### PR TITLE
Disable OSIRIS FuryFitMulti test on OSX

### DIFF
--- a/SystemTests/AnalysisTests/ISISIndirectInelastic.py
+++ b/SystemTests/AnalysisTests/ISISIndirectInelastic.py
@@ -1,5 +1,6 @@
 import stresstesting
 import os
+import platform
 from abc import ABCMeta, abstractmethod
 
 from mantid.simpleapi import *
@@ -1051,6 +1052,10 @@ class OSIRISFuryAndFuryFitMulti(ISISIndirectInelasticFuryAndFuryFitMulti):
 
     def __init__(self):
         ISISIndirectInelasticFuryAndFuryFitMulti.__init__(self)
+
+        # There is an issue on Mac with the Tau spectrum (#11150)
+        if platform.system() == "Darwin":
+            self.tolerance = 1.0
 
         # Fury
         self.samples = ['osi97935_graphite002_red.nxs']

--- a/SystemTests/AnalysisTests/ISISIndirectInelastic.py
+++ b/SystemTests/AnalysisTests/ISISIndirectInelastic.py
@@ -1050,12 +1050,11 @@ class ISISIndirectInelasticFuryAndFuryFitMulti(ISISIndirectInelasticBase):
 
 class OSIRISFuryAndFuryFitMulti(ISISIndirectInelasticFuryAndFuryFitMulti):
 
+    def skipTests(self):
+        return (platform.system() == "Darwin")
+
     def __init__(self):
         ISISIndirectInelasticFuryAndFuryFitMulti.__init__(self)
-
-        # There is an issue on Mac with the Tau spectrum (#11150)
-        if platform.system() == "Darwin":
-            self.tolerance = 1.0
 
         # Fury
         self.samples = ['osi97935_graphite002_red.nxs']


### PR DESCRIPTION
Fixes [#11149](http://trac.mantidproject.org/mantid/ticket/11149).

Gets round the failing test while it is investigated further.