### PR TITLE
Refactor PoldiSpectrumDomainFunction to use arbitrary peak profile functions

### DIFF
--- a/SystemTests/AnalysisTests/POLDIFitPeaks2DTest.py
+++ b/SystemTests/AnalysisTests/POLDIFitPeaks2DTest.py
@@ -27,35 +27,45 @@ class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
   def loadReferenceSpectrum(self, filenames):
     for dataFile in filenames:
       Load(Filename="%s_2d_reference_Spectrum.nxs" % (dataFile), OutputWorkspace="%s_2d_reference_Spectrum" % (dataFile))
+      LoadInstrument(Workspace="%s_2d_reference_Spectrum" % (dataFile), InstrumentName="POLDI")
       Load(Filename="%s_1d_reference_Spectrum.nxs" % (dataFile), OutputWorkspace="%s_1d_reference_Spectrum" % (dataFile))
 
   def runCalculateSpectrum2D(self, filenames):
     for dataFile in filenames:
-      PoldiFitPeaks2D(InputWorkspace=dataFile,
+      PoldiFitPeaks2D(InputWorkspace="%s_2d_reference_Spectrum" % (dataFile),
                                PoldiPeakWorkspace="%s_reference_Peaks" % (dataFile),
-                               PeakProfileFunction="Gaussian",
+                               FitConstantBackground=False, FitLinearBackground=False,
                                RefinedPoldiPeakWorkspace="%s_refined_Peaks" % (dataFile),
                                OutputWorkspace="%s_2d_calculated_Spectrum" % (dataFile),
                                Calculated1DSpectrum="%s_1d_calculated_Spectrum" % (dataFile),
-                               MaximumIterations=0)
+                               MaximumIterations=100)
 
   def analyseResults(self, filenames):
     for dataFile in filenames:
       calculatedSpectrum = mtd["%s_2d_calculated_Spectrum" % (dataFile)]
       referenceSpectrum = mtd["%s_2d_reference_Spectrum" % (dataFile)]
 
+      referencePeaks = mtd["%s_reference_Peaks" % (dataFile)]
+      fittedPeaks = mtd["%s_refined_Peaks" % (dataFile)]
+
       self.assertEqual(calculatedSpectrum.getNumberHistograms(), referenceSpectrum.getNumberHistograms())
 
-      for i in range(calculatedSpectrum.getNumberHistograms()):
-        calHisto = calculatedSpectrum.readY(i)
+      columns = ["d", "FWHM (rel.)", "Intensity"]
 
-        if not referenceSpectrum.getDetector(i).isMasked():
-          refHisto = referenceSpectrum.readY(i)
+      for i in range(referencePeaks.rowCount()):
+          referenceRow = referencePeaks.row(i)
+          fittedRow = fittedPeaks.row(i)
+          for c in columns:
+              fittedStr = fittedRow[c].split()
+              value, error = (float(fittedStr[0]), float(fittedStr[-1]))
+              reference = float(referenceRow[c])
 
-          absDiff = np.fabs(refHisto - calHisto)
-          self.assertTrue(np.all(absDiff < 7e-4))
-        else:
-          self.assertTrue(np.all(calHisto == 0.0))
+              if c == "FWHM (rel.)":
+                error *= 3.0
+
+              #print i,c,np.fabs(value - reference)/error, reference
+              self.assertLessThan(np.fabs(value - reference), error)
+
 
       spectra1D = ["%s_1d_%s_Spectrum"]
 
@@ -73,4 +83,4 @@ class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
         maxDifference = np.abs(np.max((yDataCalc[indices] - yDataRef[indices]) / yDataCalc[indices]))
 
         self.assertTrue(np.all(xDataCalc == xDataRef))
-        self.assertLessThan(maxDifference, 0.0031)
+        self.assertLessThan(maxDifference, 0.07)

--- a/SystemTests/AnalysisTests/POLDIFitPeaks2DTest.py
+++ b/SystemTests/AnalysisTests/POLDIFitPeaks2DTest.py
@@ -50,7 +50,7 @@ class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
 
       self.assertEqual(calculatedSpectrum.getNumberHistograms(), referenceSpectrum.getNumberHistograms())
 
-      columns = ["d", "FWHM (rel.)", "Intensity"]
+      columns = ["d", "Intensity"]
 
       for i in range(referencePeaks.rowCount()):
           referenceRow = referencePeaks.row(i)
@@ -60,10 +60,6 @@ class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
               value, error = (float(fittedStr[0]), float(fittedStr[-1]))
               reference = float(referenceRow[c])
 
-              if c == "FWHM (rel.)":
-                error *= 3.0
-
-              #print i,c,np.fabs(value - reference)/error, reference
               self.assertLessThan(np.fabs(value - reference), error)
 
 


### PR DESCRIPTION
The system test for PoldiFitPeaks2D was modified to be compatible with the changes in [#10996](http://trac.mantidproject.org/mantid/ticket/10996). Instead of directly comparing intensities, a fit is now performed and the outcome is compared against reference values.

This needs to be verified together with pull request [#270](https://github.com/mantidproject/mantid/pull/270).
